### PR TITLE
Fix property key typo

### DIFF
--- a/pruebatecnica/src/main/resources/application.properties
+++ b/pruebatecnica/src/main/resources/application.properties
@@ -1,3 +1,3 @@
-sprint.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mysql://localhost:3306/prueba_tecnica
 spring.datasource.username=root


### PR DESCRIPTION
## Summary
- fix typo in application.properties

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3ff1c6888325821e9c337812264f